### PR TITLE
Add ingest daemon crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ingestd"
+version = "0.1.0"
+dependencies = [
+ "agents",
+ "api",
+ "ingest-core",
+ "ops",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "crates/api",
     "crates/ops",
     "crates/devtools",
+    "crates/ingestd",
 ]
 resolver = "2"

--- a/crates/ingestd/Cargo.toml
+++ b/crates/ingestd/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ingestd"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+ingest-core = { path = "../core" }
+agents = { path = "../agents" }
+api = { path = "../api" }
+ops = { path = "../ops" }
+toml = "0.8"
+

--- a/crates/ingestd/src/main.rs
+++ b/crates/ingestd/src/main.rs
@@ -1,0 +1,41 @@
+use std::{env, fs, net::SocketAddr};
+
+use agents::{binance::BinanceAdapter, Adapter};
+use api::EventBus;
+use ingest_core::config::Config;
+use ops::OpsServer;
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cfg_path = env::args().nth(1).expect("config path required");
+    let data = fs::read_to_string(cfg_path)?;
+    let cfg: Config = toml::from_str(&data)?;
+
+    let bus = EventBus::new(1024);
+    let publisher = bus.publisher();
+
+    let ops = OpsServer::new();
+    let ops_addr: SocketAddr = "127.0.0.1:3000".parse().unwrap();
+    let ops_handle = tokio::spawn(ops.run(ops_addr));
+
+    let (tx, mut rx) = mpsc::channel(100);
+    let forward_handle = tokio::spawn(async move {
+        while let Some(evt) = rx.recv().await {
+            publisher.publish(evt);
+        }
+    });
+
+    for venue in cfg.venues {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let adapter = BinanceAdapter;
+            if let Err(e) = adapter.connect(venue, tx).await {
+                eprintln!("adapter error: {e}");
+            }
+        });
+    }
+
+    let _ = tokio::join!(ops_handle, forward_handle);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `ingestd` binary crate to run adapters, event bus, and ops server
- wire config-driven adapter startup into async runtime
- expose new crate in workspace

## Testing
- `cargo test`
- `cargo run -p ingestd -- config/example.toml`


------
https://chatgpt.com/codex/tasks/task_e_68a68f1724548323a568b9af7b9089a3