### PR TITLE
Add Binance symbol discovery and ticker streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "ingest-core",
  "proc-macro2",
  "quote",
+ "reqwest",
  "serde",
  "serde_json",
  "syn 1.0.109",

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 toml = "0.8"
 tokio-tungstenite = { version = "0.21", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 futures-util = "0.3"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [dependencies.proc-macro2]
 version = "1"


### PR DESCRIPTION
## Summary
- support symbol discovery via `symbols = "ALL"` with discovery filters
- add `discover_symbols` for Binance that queries `/exchangeInfo`
- generate trade and ticker WebSocket stream names for all enabled channels

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aba3ffd1688323954a3708a6a1d0eb