### PR TITLE
feat: add reconnect backoff for Binance adapter

### DIFF
--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 ingest-core = { path = "../core" }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt", "macros", "sync" ] }
+tokio = { version = "1", features = ["rt", "macros", "sync", "time" ] }
 chrono = { version = "0.4", features = ["serde", "clock" ] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
## Summary
- retry Binance websocket connection with exponential backoff
- reconnect after read errors or EOF
- exit gracefully when shutdown is signalled

## Testing
- `cargo fmt --all`
- `cargo test`
- `cargo test -p agents`


------
https://chatgpt.com/codex/tasks/task_e_68abb355acb883239cf4a5f6aa8f65c2